### PR TITLE
Update Scripts

### DIFF
--- a/fixdatabase.sh
+++ b/fixdatabase.sh
@@ -11,5 +11,8 @@ plexdocker="plex"
     sqlite3 "$plexdb" "pragma page_size=32768; vacuum;"
     sqlite3 "$plexdb" "pragma default_cache_size=20000000"
     sqlite3 "$plexdb" < /tmp/dump.sql
+    sqlite3 "$plexdb" "UPDATE metadata_items SET added_at = originally_available_at WHERE added_at <> originally_available_at AND originally_available_at IS NOT NULL;"
+    sqlite3 "$plexdb" "UPDATE metadata_items SET added_at = DATETIME('now', '-1 days') WHERE DATETIME(added_at) > DATETIME('now');"
+    sqlite3 "$plexdb" "UPDATE metadata_items SET added_at = DATETIME('now', '-1 days') WHERE DATETIME(originally_available_at) > DATETIME('now');"
     chown seed:seed "$plexdb"
     docker start "${plexdocker}"

--- a/pac.sh
+++ b/pac.sh
@@ -11,6 +11,6 @@
 #
 #
 /bin/mkdir -P /opt/pac
-/usr/bin/rclone -vvv rc vfs/refresh dir=/zd-inbound recursive=false --rc-addr=localhost:$2
-/usr/bin/rclone -vvv rc vfs/refresh dir=/zd-inbound recursive=true --rc-addr=localhost:$2
+/usr/bin/rclone -vvv rc vfs/refresh dir=/zd-inbound/inbound/librarybase/collections recursive=false --rc-addr=localhost:$2
+/usr/bin/rclone -vvv rc vfs/refresh dir=/zd-inbound/inbound/librarybase/collections recursive=true --rc-addr=localhost:$2
 /usr/bin/docker run --rm -it -d --network="docker_default" --name pac -v /opt/pac:/config -v /mnt/unionfs/inbound/librarybase/collections/posters:/config/posters -e PLEXAPI_PLEXAPI_TIMEOUT=60 mza921/plex-auto-collections -u -c /config/$1

--- a/pumpanddump.sh
+++ b/pumpanddump.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-sudo pkil -9 docker
+sudo pkill -9 docker
 sudo service docker stop
 cd /opt/plex/Library/Application\ Support/Plex\ Media\ Server/Plug-in\ Support/Databases/
 cp com.plexapp.plugins.library.db com.plexapp.plugins.library.db.original
@@ -7,13 +7,10 @@ sqlite3 com.plexapp.plugins.library.db "DROP index 'index_title_sort_naturalsort
 sqlite3 com.plexapp.plugins.library.db "DELETE from schema_migrations where version='20180501000000'"
 sqlite3 com.plexapp.plugins.library.db .dump > dump.sql
 rm com.plexapp.plugins.library.db
-sqlite3 com.plexapp.plugins.library.db < dump.sql
-sqlite3 com.plexapp.plugins.library.db "pragma synchronous = normal"
-sqlite3 com.plexapp.plugins.library.db "pragma cache_size = 15000000"
-sqlite3 com.plexapp.plugins.library.db "pragma temp_store = memory"
-sqlite3 com.plexapp.plugins.library.db "pragma mmap_size = 30000000000"
-sqlite3 com.plexapp.plugins.library.db "pragma page_size = 32768"
-sqlite3 com.plexapp.plugins.library.db "pragma vacuum"
+sqlite3 com.plexapp.plugins.library.db "pragma page_size=32768; vacuum;"
+sqlite3 com.plexapp.plugins.library.db "pragma default_cache_size = 20000000; vacuum;"
+sqlite3 com.plexapp.plugins.library.db <dump.sql
+sqlite3 com.plexapp.plugins.library.db "vacuum"
 sqlite3 com.plexapp.plugins.library.db "pragma optimize"
 cd ~/
 sudo service docker start


### PR DESCRIPTION
narrow down the zd-inbound update, no need to update the entire mount.