### PR TITLE
Add Tautulli path mapping to Plex logs.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,6 +102,7 @@ services:
       - "/etc/localtime:/etc/localtime:ro"
       - "${APPDATA_ROOT}/tautulli:/config"
       - "${APPDATA_ROOT}/tautulli/transcode:/transcode"
+      - "${APPDATA_ROOT}/plex/Library/Application Support/Plex Media Server/Logs:/logs"
     environment:
       PUID: "${UID}"
       PGID: "${UID}"


### PR DESCRIPTION
Allows Tautulli to show plex logs, needs that volume mapping in. This is to match the main branch.